### PR TITLE
Fix default nft loading on shared links

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -801,6 +801,7 @@ function EditorPage() {
   const [tokenID, setTokenID] = useState<string | number>(1507);
   const [tempTokenID, setTempTokenID] = useState<string | number>(1507);
   const [isFirstRender, setIsFirstRender] = useState(true);
+  const [urlParamsParsed, setUrlParamsParsed] = useState(false);
   const [collectionIndex, setCollectionIndex] = useState(2);
   const [x, setX] = useState(650);
   const [y, setY] = useState(71);
@@ -1041,6 +1042,9 @@ function EditorPage() {
       setWalletInput(walletIdParam);
       setActiveTab("loadwallet");
     }
+
+    // Mark URL params as parsed
+    setUrlParamsParsed(true);
   }, []);
 
   const updateUrlParams = useCallback(() => {
@@ -1576,6 +1580,11 @@ function EditorPage() {
   }, [updateUrlParams, isFirstRender]);
 
   useEffect(() => {
+    // Don't fetch image until URL params have been parsed to avoid loading default NFT first
+    if (!urlParamsParsed) {
+      return;
+    }
+
     (async () => {
       console.log("Fetching image for", { collectionIndex, tokenID });
       if (
@@ -1612,7 +1621,14 @@ function EditorPage() {
       }
       console.log("Set imageUrl:", imageUrl);
     })();
-  }, [collectionIndex, collectionMetadata, maxTokenID, minTokenID, tokenID]);
+  }, [
+    collectionIndex,
+    collectionMetadata,
+    maxTokenID,
+    minTokenID,
+    tokenID,
+    urlParamsParsed,
+  ]);
 
   const encodedImageUrl = useMemo(() => {
     console.log("encodedImageUrl useMemo:", imageUrl);


### PR DESCRIPTION
Delay NFT image loading until URL parameters are parsed to ensure the correct NFT loads immediately from shared links.

Previously, the image loading effect would run immediately on component mount with default NFT values, before URL parameters were processed. This caused the default NFT to briefly display before the correct NFT from the URL was loaded. This PR introduces a `urlParamsParsed` state to gate the initial image fetch, ensuring the correct NFT is loaded from the start.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ad631085-209b-467d-842a-ec5e29532507) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ad631085-209b-467d-842a-ec5e29532507)